### PR TITLE
refactor: simplify IRecipe interface pycorelib

### DIFF
--- a/src/profiles-pycorelib/attribution_model.py
+++ b/src/profiles-pycorelib/attribution_model.py
@@ -204,7 +204,7 @@ class AttributionModelRecipe(PyNativeRecipe):
         return  description, ".txt"
 
     # prepare the material for execution - de_ref the inputs and create the sql code
-    def prepare(self, this: WhtMaterial):
+    def register_dependencies(self, this: WhtMaterial):
         this.de_ref(self.inputs["touchpoints"])
         this.de_ref(self.inputs["days_since_first_seen"])
         this.de_ref(self.inputs["conversion"])

--- a/src/profiles-pycorelib/common_col_union.py
+++ b/src/profiles-pycorelib/common_col_union.py
@@ -38,7 +38,48 @@ class CommonColumnUnionRecipe(PyNativeRecipe):
     def describe(self, this: WhtMaterial):
         return self.sql, ".sql"
 
-    def prepare(self, this: WhtMaterial):
+    def register_dependencies(self, this: WhtMaterial):
+        is_null_ctx = this.wht_ctx.is_null_ctx
+        if is_null_ctx:
+            for in_model in self.inputs:
+                this.de_ref(in_model, edge_type="optional")
+            return
+        
+        inputs = [] # enabled inputs
+        common_columns_count = {}
+        for in_model in self.inputs:
+            in_material = this.de_ref(in_model, edge_type="optional")
+            if in_material is None:
+                continue # disabled
+
+            inputs.append(in_model)
+
+        union_sql = ""
+        union_queries = []
+        for in_model in inputs:
+            union_queries.append(
+            f"""{{% with input_mat = this.DeRef('{in_model}') %}}
+                    select  <determined at runtime> from {{{{input_mat}}}}
+                {{% endwith %}}"""
+            )
+            
+        union_sql = " UNION ALL ".join(union_queries)
+        
+        
+        sql = this.execute_text_template(
+            f"""
+            {{% macro begin_block() %}}
+                {{% macro selector_sql() %}}
+                    {union_sql}
+                {{% endmacro %}}
+                {{% exec %}} {{{{warehouse.CreateReplaceTableAs(this.Name(), selector_sql())}}}} {{% endexec %}}
+            {{% endmacro %}}
+            
+            {{% exec %}} {{{{warehouse.BeginEndBlock(begin_block())}}}} {{% endexec %}}"""
+        )
+        self.sql = sql            
+
+    def execute(self, this: WhtMaterial):
         is_null_ctx = this.wht_ctx.is_null_ctx
         if is_null_ctx:
             for in_model in self.inputs:
@@ -98,9 +139,7 @@ class CommonColumnUnionRecipe(PyNativeRecipe):
             
             {{% exec %}} {{{{warehouse.BeginEndBlock(begin_block())}}}} {{% endexec %}}"""
         )
-        self.sql = sql            
-
-    def execute(self, this: WhtMaterial):
+        self.sql = sql        
         if self.sql == "":
             self.logger.error("error executing common_column_union_recipe, sql is empty")
         


### PR DESCRIPTION
## Description of the change

This PR aims to modify the pyNative models in pycorelib according to the changes made in [PR#1229](https://github.com/rudderlabs/wht/pull/1229) in wht. prepare is renamed to register_dependencies and is resposible for adding all inputs and preparing a dry sql or py, without hitting the warehouse, that will not be executed, execute has same name but it's behaviour has modified such that it also prepares the actual sql that will be run and executed.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
