### PR TITLE
chore: strip v prefix from limit_major_minor_version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def limit_major_minor_version(version: str) -> str:
         >>> limit_major_minor_version("1.2.3")
         '1.2.*'
     """
-    return ".".join(version.split(".")[:2]) + ".*"
+    return ".".join(version.split(".")[:2]).replace('v', '') + ".*"
 
 
 setup(


### PR DESCRIPTION
## Description of the change

removing the v prefix from the version returned by `limit_major_minor_version`