### PR TITLE
using torch for converge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "matplotlib>=3.7.5",
         "pandas>=2.0.3,<2.2.0",
         "numpy>=1.24.4",
-        "scipy>=1.13.0",
-        "plotly>=5.22.0"
+        "plotly>=5.22.0",
+        "torch"
     ]
 )

--- a/src/profiles-pycorelib/attribution_model.py
+++ b/src/profiles-pycorelib/attribution_model.py
@@ -6,7 +6,7 @@ from profiles_rudderstack.material import WhtMaterial
 from profiles_rudderstack.logger import Logger
 import seaborn as sns
 import matplotlib
-import scipy.linalg as linalg
+import torch
 import plotly.graph_objects as go
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
@@ -132,21 +132,22 @@ class MultiTouchModels:
         all_transitions = pos_transitions + neg_transitions
         transition_probabilities = row_normalize_np_array(all_transitions)
         return transition_probabilities, labels
-    
+
     def _converge(self, transition_matrix, max_iters=40, verbose=False):
-        transition_matrix = np.array(transition_matrix, dtype=np.float32)
-        T_upd = transition_matrix.copy()
-        prev_T = transition_matrix.copy()
+        transition_matrix = torch.tensor(transition_matrix, dtype=torch.float32)
+        T_upd = transition_matrix
+        prev_T = transition_matrix
+
         for i in range(max_iters):
-            T_upd = linalg.blas.dgemm(1.0, transition_matrix, prev_T)
-            if np.abs(T_upd - prev_T).max() < 1e-3:
+            T_upd = torch.matmul(transition_matrix, prev_T)
+            if torch.abs(T_upd - prev_T).max() < 1e-3:
                 if verbose:
                     self.logger.info(f"{i} iters taken for convergence")
-                return T_upd
+                return T_upd.numpy()
             prev_T = T_upd
         if verbose:
             self.logger.info(f"Max iters of {max_iters} reached before convergence. Exiting")
-        return T_upd
+        return T_upd.numpy() 
     
     def _get_removal_affects(self, transition_probs, labels, ignore_labels=["Start", "Dropoff","Converted"], default_conversion=1.):
         removal_affect = {}


### PR DESCRIPTION
## Description of the change

> torch is comparatively faster than scipy.linalg for matmul. Ticket [link](https://linear.app/rudderstack/issue/PRML-673/use-torch-in-attribution-converge-function).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
