### PR TITLE
reverting converge() from torch to scipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
         "pandas>=2.0.3,<2.2.0",
         "numpy>=1.24.4",
         "plotly>=5.22.0",
-        "torch"
+        "scipy>=1.13.0"
     ]
 )


### PR DESCRIPTION
## Description of the change

> using scipy instead of torch to prevent bloating the docker image size. Ticket [link](https://linear.app/rudderstack/issue/PRML-711/move-main-branch-to-scipy-to-prevent-bloating-the-docker-image-size).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
