### PR TITLE
ci: open PR for release version bump instead of pushing to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,5 +83,4 @@ jobs:
             --base main \
             --head ${BRANCH} \
             --title "chore: release ${VERSION}" \
-            --body "Automated version bump for release ${VERSION}."
-          gh pr merge ${BRANCH} --squash --auto --delete-branch
+            --body "Automated version bump for release ${VERSION}. The tag and GitHub release have already been published; merging this PR keeps main in sync with the released version."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,4 +74,14 @@ jobs:
         run: |
           git push origin ${VERSION}
           gh release create ${VERSION} $(echo $VERSION | grep -q "alpha\|beta\|rc" && echo "-p") --generate-notes profiles_pycorelib_dist_${VERSION}.tar.gz dist/*.whl
-          git push origin HEAD
+      - name: open PR to land version bump on main
+        shell: bash
+        run: |
+          BRANCH="release/${VERSION}"
+          git push origin HEAD:refs/heads/${BRANCH}
+          gh pr create \
+            --base main \
+            --head ${BRANCH} \
+            --title "chore: release ${VERSION}" \
+            --body "Automated version bump for release ${VERSION}."
+          gh pr merge ${BRANCH} --squash --auto --delete-branch


### PR DESCRIPTION
## Summary
- Org branch protection on `main` now requires PRs, breaking the final `git push origin HEAD` of the release workflow.
- Replace it with: push the version-bump commit to a `release/${VERSION}` branch and open a PR.
- Tag, GitHub release, and wheel are still published earlier in the same workflow run — they don't depend on the PR merge. A human merging the PR is the final step that keeps `main`'s `version.py` in sync with the released version.

RESOLVES: PRO-5666

## Test plan
- [ ] Trigger workflow_dispatch on this branch with a throwaway pre-release version
- [ ] Confirm tag and GitHub release are created
- [ ] Confirm a `release/...` branch + PR are opened
- [ ] Merge the PR, confirm main's version.py updates
- [ ] Clean up the test tag/release/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)