### PR TITLE
chore: release v0.25.0-alpha.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,5 +83,4 @@ jobs:
             --base main \
             --head ${BRANCH} \
             --title "chore: release ${VERSION}" \
-            --body "Automated version bump for release ${VERSION}."
-          gh pr merge ${BRANCH} --squash --auto --delete-branch
+            --body "Automated version bump for release ${VERSION}. The tag and GitHub release have already been published; merging this PR keeps main in sync with the released version."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,4 +74,14 @@ jobs:
         run: |
           git push origin ${VERSION}
           gh release create ${VERSION} $(echo $VERSION | grep -q "alpha\|beta\|rc" && echo "-p") --generate-notes profiles_pycorelib_dist_${VERSION}.tar.gz dist/*.whl
-          git push origin HEAD
+      - name: open PR to land version bump on main
+        shell: bash
+        run: |
+          BRANCH="release/${VERSION}"
+          git push origin HEAD:refs/heads/${BRANCH}
+          gh pr create \
+            --base main \
+            --head ${BRANCH} \
+            --title "chore: release ${VERSION}" \
+            --body "Automated version bump for release ${VERSION}."
+          gh pr merge ${BRANCH} --squash --auto --delete-branch

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 
-version = "v0.25.0"
+version = "v0.25.0-alpha.1"


### PR DESCRIPTION
Automated version bump for release v0.25.0-alpha.1. The tag and GitHub release have already been published; merging this PR keeps main in sync with the released version.