### PR TITLE
chore: release v0.26.0-alpha.2

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 
-version = "v0.25.0"
+version = "v0.26.0-alpha.2"


### PR DESCRIPTION
Automated version bump for release v0.26.0-alpha.2. The tag and GitHub release have already been published; merging this PR keeps main in sync with the released version.