### PR TITLE
chore: release 0.26.0-rc.1

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 
-version = "v0.26.0-alpha.2"
+version = "0.26.0-rc.1"


### PR DESCRIPTION
Automated version bump for release 0.26.0-rc.1. The tag and GitHub release have already been published; merging this PR keeps main in sync with the released version.