### PR TITLE
fix(attribution): block pandas df.query() code injection in campaign_attribution_scores (RUD-3028)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,8 @@ release: check_git update_version
 .PHONY: install
 install:
 	SKIP_PB_BIN=true pip3 install .
+
+.PHONY: test
+test:
+	pip3 install -r tests/requirements.txt
+	pytest tests/

--- a/src/profiles-pycorelib/attribution_model.py
+++ b/src/profiles-pycorelib/attribution_model.py
@@ -15,9 +15,35 @@ import numpy as np
 import os
 import time
 import pathlib
+import re
 
 matplotlib.use('agg')
 MAXIMUM_TOUCHPOINTS_TO_VISUALIZE = 50
+
+# Column names supplied through the build spec are used to filter/index the input
+# dataframe. They must be bare identifiers, never expressions: pandas'
+# DataFrame.query()/eval engine resolves "@name" against this module's globals
+# (which include os, time, pathlib), so an unvalidated field would let a config
+# value run arbitrary Python in the pb runner process (RUD-3028).
+_COLUMN_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_column_name(name: str, df: pd.DataFrame) -> str:
+    """Return ``name`` only if it is a bare column identifier present in ``df``.
+
+    Raises ``ValueError`` otherwise, so a build-spec field can never be
+    interpreted as a pandas/Python expression.
+    """
+    if not isinstance(name, str) or not _COLUMN_NAME_RE.match(name):
+        raise ValueError(
+            f"Invalid column name {name!r}: expected a bare column identifier "
+            "matching [A-Za-z_][A-Za-z0-9_]*"
+        )
+    if name not in df.columns:
+        raise ValueError(
+            f"Column {name!r} not found in input columns: {list(df.columns)}"
+        )
+    return name
 
 class AttributionModel(BaseModelType):
     TypeName = "campaign_attribution_scores" # the name of the model type
@@ -195,11 +221,13 @@ class MultiTouchModels:
         return attributable_conversions
     
     def get_markov_attribution(self, input_df: pd.DataFrame, conversion_col: str, touchpoints_array_col: str, attribution_reports_folder_path: str, enable_visualisation: bool) -> pd.DataFrame:
+        conversion_col = _validate_column_name(conversion_col, input_df)
+        touchpoints_array_col = _validate_column_name(touchpoints_array_col, input_df)
         data_filtered = input_df[input_df[touchpoints_array_col].apply(lambda touches: len(touches)>0 if touches else False)]
-        positive_touchpoints_ = data_filtered.query(f"{conversion_col}>0")[[touchpoints_array_col, conversion_col]].values
+        positive_touchpoints_ = data_filtered[data_filtered[conversion_col] > 0][[touchpoints_array_col, conversion_col]].values
         positive_touches = [val[0] for val in positive_touchpoints_]
         conversion_weights = [val[1] for val in positive_touchpoints_]
-        negative_touchpoints_ = data_filtered.query(f"{conversion_col}==0")[[touchpoints_array_col]].values
+        negative_touchpoints_ = data_filtered[data_filtered[conversion_col] == 0][[touchpoints_array_col]].values
         negative_touches = [val[0] for val in negative_touchpoints_]
         distinct_touches = sorted(list(set([item for sublist in positive_touches + negative_touches for item in sublist])))
         scores = self._get_markov_scores(positive_touches, negative_touches, distinct_touches, journey_weights=conversion_weights, attribution_reports_folder_path=attribution_reports_folder_path, enable_visualisation=enable_visualisation)
@@ -288,7 +316,8 @@ class AttributionModelRecipe(PyNativeRecipe):
 
         if 'days_since_first_seen_var' in self.config:
             days_since_first_seen_var = self.config['days_since_first_seen_var'].lower()
-            filtered_df = input_df.query(f"{days_since_first_seen_var} <= {self.config['first_seen_since']}").copy()
+            column = _validate_column_name(days_since_first_seen_var, input_df)
+            filtered_df = input_df[input_df[column] <= self.config['first_seen_since']].copy()
         else:
             filtered_df = input_df.copy()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,102 @@
+"""Shared test fixtures for profiles-pycorelib.
+
+The model modules import ``profiles_rudderstack`` at module scope. That package
+talks to the ``pb`` runtime over a local gRPC tunnel and is not installable in a
+plain unit-test environment, so we stub the handful of symbols the models import.
+Everything else (pandas, numpy, scipy, matplotlib, seaborn, plotly) is the real
+library, so the code under test runs unmodified.
+"""
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_MODELS_DIR = _REPO_ROOT / "src" / "profiles-pycorelib"
+
+
+def _install_profiles_rudderstack_stubs() -> None:
+    if "profiles_rudderstack" in sys.modules:
+        return
+
+    root = types.ModuleType("profiles_rudderstack")
+    sys.modules["profiles_rudderstack"] = root
+
+    model = types.ModuleType("profiles_rudderstack.model")
+
+    class BaseModelType:
+        def __init__(self, build_spec, schema_version, pb_version):
+            self.build_spec = build_spec
+            self.schema_version = schema_version
+            self.pb_version = pb_version
+
+    model.BaseModelType = BaseModelType
+    sys.modules["profiles_rudderstack.model"] = model
+
+    schema = types.ModuleType("profiles_rudderstack.schema")
+    for name in (
+        "ContractBuildSpecSchema",
+        "EntityKeyBuildSpecSchema",
+        "EntityIdsBuildSpecSchema",
+        "MaterializationBuildSpecSchema",
+    ):
+        setattr(schema, name, {"properties": {}})
+    sys.modules["profiles_rudderstack.schema"] = schema
+
+    recipe = types.ModuleType("profiles_rudderstack.recipe")
+
+    class PyNativeRecipe:
+        pass
+
+    recipe.PyNativeRecipe = PyNativeRecipe
+    sys.modules["profiles_rudderstack.recipe"] = recipe
+
+    material = types.ModuleType("profiles_rudderstack.material")
+
+    class WhtMaterial:
+        pass
+
+    material.WhtMaterial = WhtMaterial
+    sys.modules["profiles_rudderstack.material"] = material
+
+    logger = types.ModuleType("profiles_rudderstack.logger")
+
+    class Logger:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def info(self, *args, **kwargs):
+            pass
+
+        def warn(self, *args, **kwargs):
+            pass
+
+        def warning(self, *args, **kwargs):
+            pass
+
+        def error(self, *args, **kwargs):
+            pass
+
+        def debug(self, *args, **kwargs):
+            pass
+
+    logger.Logger = Logger
+    sys.modules["profiles_rudderstack.logger"] = logger
+
+
+def _load_model_module(module_name: str):
+    _install_profiles_rudderstack_stubs()
+    path = _MODELS_DIR / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def attribution_model():
+    """The real ``attribution_model`` module, loaded from source."""
+    return _load_model_module("attribution_model")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,10 @@
+# Test-only dependencies. The models import profiles_rudderstack at module
+# scope; the tests stub it (see conftest.py) because it needs the pb runtime,
+# so only the scientific stack + pytest are required to run the suite.
+pandas>=2.0.3
+numpy>=1.24.4
+scipy>=1.11.0
+matplotlib>=3.7.5
+seaborn>=0.13.1
+plotly>=5.22.0
+pytest>=7.0

--- a/tests/test_attribution_injection.py
+++ b/tests/test_attribution_injection.py
@@ -1,0 +1,142 @@
+"""Regression tests for pandas ``df.query()`` code injection in the
+``campaign_attribution_scores`` model (RUD-3028 / HackerOne #3912408).
+
+A build-spec field was interpolated, unescaped, into ``DataFrame.query()``.
+pandas resolves ``@name`` against module globals, and the module imports ``os``,
+so ``@os.system(...)`` in a config field executed arbitrary shell commands in the
+pb runner process. These tests prove such a payload is rejected, not executed.
+"""
+import pathlib
+
+import pandas as pd
+import pytest
+
+
+class _FakeRef:
+    def __init__(self, df):
+        self._df = df
+
+    def get_df(self):
+        return self._df
+
+
+class _FakeMaterial:
+    """Minimal stand-in for WhtMaterial covering what execute() touches."""
+
+    def __init__(self, df, output_folder):
+        self._df = df
+        self._output_folder = str(output_folder)
+
+    def de_ref(self, _key):
+        return _FakeRef(self._df.copy())
+
+    def get_output_folder(self):
+        return self._output_folder
+
+    def name(self):
+        return "test_material"
+
+    def write_output(self, _df):
+        return None
+
+
+def _input_df():
+    return pd.DataFrame(
+        {
+            "days_since_first_seen": [1, 5, 40],
+            "campaign": ["email", "ads", "social"],
+            "converted": [1, 0, 1],
+        }
+    )
+
+
+def test_days_since_first_seen_var_injection_is_rejected(attribution_model, tmp_path):
+    # execute() lower-cases the field, so keep the sentinel path lower-case too.
+    sentinel = pathlib.Path(str(tmp_path / "pwned.txt").lower())
+    payload = f'days_since_first_seen+@os.system("touch {sentinel}")'
+    config = {
+        "entity": "user",
+        "touchpoint_var": "campaign",
+        "conversion_entity_var": "converted",
+        "days_since_first_seen_var": payload,
+        "first_seen_since": 100,
+        "enable_visualisation": False,
+    }
+    recipe = attribution_model.AttributionModelRecipe(config)
+    material = _FakeMaterial(_input_df(), tmp_path)
+
+    # The fixed code must reject the non-identifier column name with a ValueError.
+    with pytest.raises(ValueError):
+        recipe.execute(material)
+
+    assert not sentinel.exists(), (
+        "injected shell command executed via df.query() — RCE not fixed"
+    )
+
+
+def test_markov_conversion_col_injection_is_rejected(attribution_model, tmp_path):
+    sentinel = tmp_path / "pwned_markov.txt"
+    payload = f'converted+@os.system("touch {sentinel}")'
+    df = pd.DataFrame(
+        {
+            "touchpoints": [["email", "ads"], ["social"]],
+            "converted": [1, 0],
+        }
+    )
+    models = attribution_model.MultiTouchModels(logger=attribution_model.Logger("t"))
+
+    with pytest.raises(ValueError):
+        models.get_markov_attribution(df, payload, "touchpoints", str(tmp_path), False)
+
+    assert not sentinel.exists(), "injected shell command executed via markov df.query()"
+
+
+def test_validate_column_name_accepts_identifiers_and_rejects_expressions(attribution_model):
+    df = _input_df()
+    validate = attribution_model._validate_column_name
+
+    assert validate("days_since_first_seen", df) == "days_since_first_seen"
+
+    for bad in [
+        'days_since_first_seen+@os.system("id")',
+        "@os",
+        "a; b",
+        "col name",
+        "days_since_first_seen ",
+        "1col",
+        "nonexistent_column",
+    ]:
+        with pytest.raises(ValueError):
+            validate(bad, df)
+
+
+def test_valid_config_filters_by_days_and_completes(attribution_model, tmp_path):
+    captured = {}
+
+    class _CapturingMaterial(_FakeMaterial):
+        def write_output(self, df):
+            captured["output"] = df
+
+    df = pd.DataFrame(
+        {
+            "days_since_first_seen": [1, 5, 8, 40, 60],
+            "campaign": ["email", "ads", "email,ads", "social", "social,email"],
+            "converted": [1, 0, 1, 1, 0],
+        }
+    )
+    config = {
+        "entity": "user",
+        "touchpoint_var": "campaign",
+        "conversion_entity_var": "converted",
+        "days_since_first_seen_var": "days_since_first_seen",
+        "first_seen_since": 10,
+        "enable_visualisation": False,
+    }
+    recipe = attribution_model.AttributionModelRecipe(config)
+
+    recipe.execute(_CapturingMaterial(df, tmp_path))
+
+    touchpoints = set(captured["output"]["campaign"])
+    assert "email" in touchpoints
+    # rows with days_since_first_seen > 10 (the "social" touchpoints) are filtered out
+    assert "social" not in touchpoints


### PR DESCRIPTION
## What & why

Fixes **RUD-3028** (sub-task of **RUD-3027** / HackerOne #3912408): a pandas
`DataFrame.query()` injection in the `campaign_attribution_scores` model that
gave arbitrary Python execution in the `pb` runner process.

Build-spec fields (`days_since_first_seen_var`, `conversion_entity_var`) were
interpolated **unescaped** into `df.query()` f-strings. pandas resolves `@name`
against module globals, and this module imports `os`, `time`, `pathlib` at module
scope — so a config value like `days_since_first_seen+@os.system("...")` ran
shell commands on the host executing the model, with that host's warehouse
credentials and network position.

## The three sinks (all fixed)

| Location | Field | Before |
|---|---|---|
| `execute()` | `days_since_first_seen_var` | `input_df.query(f"{days_since_first_seen_var} <= {first_seen_since}")` |
| `get_markov_attribution()` | `conversion_entity_var` | `data_filtered.query(f"{conversion_col}>0")` |
| `get_markov_attribution()` | `conversion_entity_var` | `data_filtered.query(f"{conversion_col}==0")` |

## Fix

- Add `_validate_column_name(name, df)`: accepts only a bare column identifier
  (`^[A-Za-z_][A-Za-z0-9_]*$`) that actually exists in the dataframe, else raises
  `ValueError`. A build-spec field can no longer be interpreted as an expression.
- Replace all three `query()` f-strings with typed boolean indexing
  (`input_df[input_df[col] <= n]`). No expression parser is involved, so there is
  nothing to inject into — the fix holds regardless of what the module imports.

## Verification

- Reproduced the RCE against current `main`: the injected command created a file
  and `execute()` completed with no error surfaced.
- After the fix the same payload raises
  `ValueError: Invalid column name '...'` and creates nothing.
- `make test` → 4 passing tests:
  - `days_since_first_seen_var` payload rejected, not executed
  - `get_markov_attribution` conversion-column payload rejected, not executed
  - `_validate_column_name` accepts identifiers, rejects expressions
  - a valid config still filters by day threshold and completes (happy path)

## Note on the ticket's third fix bullet

The ticket also suggests moving `os`/`time`/`pathlib` to function scope. I did
**not** do that: those modules are used legitimately across several methods
(`os.path.join`, `pathlib.Path`, `time.time`), and once user input can no longer
reach `query()`/`eval` the `@os` reachability is moot. Happy to add it as
defense-in-depth if reviewers prefer.

## Suggested follow-up (not in this PR)

The repo has no test CI. Consider a workflow that runs `make test` on PRs so this
regression stays closed.

---
Reviewer: this is the RUD-3028 fix — assigned on the Linear side to Chandra.
